### PR TITLE
fix(#19): Cl0p Terraform Set-up

### DIFF
--- a/Enterprise/cl0p/Resources/setup/terraform/range/_a-victim-vms.tf
+++ b/Enterprise/cl0p/Resources/setup/terraform/range/_a-victim-vms.tf
@@ -113,8 +113,7 @@ module "a-file-srv1" {
   platform          = local.platform.win-srv
   snapshot_required = true
 
-  #   ami_id            = module.defaults.ami-windows-server-2022
-  ami_id        = local.er6prod5.azkaban
+  ami_id            = module.defaults.ami-windows-server-2022
   instance_type = local.aws-vm-size-large
 
   availability_zone = var.aws-region-az
@@ -157,8 +156,7 @@ module "a-mail-srv1" {
   platform          = local.platform.win-srv
   snapshot_required = true
 
-  #   ami_id = module.defaults.ami-windows-server-2022
-  ami_id        = local.er6prod5.hangleton
+  ami_id = module.defaults.ami-windows-server-2022
   instance_type = local.aws-vm-size-large
 
   availability_zone = var.aws-region-az

--- a/Enterprise/cl0p/Resources/setup/terraform/range/_b-victim-vms.tf
+++ b/Enterprise/cl0p/Resources/setup/terraform/range/_b-victim-vms.tf
@@ -150,8 +150,7 @@ module "b-mail-srv1" {
   platform          = local.platform.win-srv
   snapshot_required = true
 
-  #   ami_id = module.defaults.ami-windows-server-2022
-  ami_id        = local.er6prod5.zonkos
+  ami_id = module.defaults.ami-windows-server-2022
   instance_type = local.aws-vm-size-large
 
   availability_zone = var.aws-region-az

--- a/Enterprise/cl0p/Resources/setup/terraform/range/_external-benevolent-vms.tf
+++ b/Enterprise/cl0p/Resources/setup/terraform/range/_external-benevolent-vms.tf
@@ -213,8 +213,7 @@ module "redirect-srv4" {
   snapshot_required = false
   scope             = local.scopes.internal
 
-  #   ami_id = module.defaults.ami-linux-ubuntu-jammy
-  ami_id = local.er6prod5.doorman
+  ami_id = module.defaults.ami-linux-ubuntu-jammy
 
   name               = local.external-benevolent-vms.redirect-srv4.vm-name
   hostname           = local.external-benevolent-vms.redirect-srv4.hostname

--- a/Enterprise/cl0p/Resources/setup/terraform/range/_victim-network.tf
+++ b/Enterprise/cl0p/Resources/setup/terraform/range/_victim-network.tf
@@ -200,7 +200,7 @@ resource "aws_subnet" "vpn" {
 
 ## openvpn
 module "openvpn-client" {
-  source            = "../../modules/aws/vpn-client"
+  source            = "../modules/aws/vpn-client"
   name              = var.name-prefix
   organization_name = local.vendor
   cidr              = local.openvpn-cidr

--- a/Enterprise/cl0p/Resources/setup/terraform/range/main.tf
+++ b/Enterprise/cl0p/Resources/setup/terraform/range/main.tf
@@ -1,6 +1,6 @@
 ## resource group
 module "defaults" {
-  source      = "../../modules/aws/defaults"
+  source      = "../modules/aws/defaults"
   name        = var.name-prefix
   description = var.description
   category    = var.category

--- a/Enterprise/cl0p/Resources/setup/terraform/range/traffic-mirroring.vendor-request
+++ b/Enterprise/cl0p/Resources/setup/terraform/range/traffic-mirroring.vendor-request
@@ -1,7 +1,7 @@
 #### Traffic Mirroring Servers usually provided by vendor
 
 # module "mirror-a" {
-#   source            = "../../modules/aws/base-vm"
+#   source            = "../modules/aws/base-vm"
 #   description       = "[Scenario A] Traffic Mirror Server"
 #   platform          = "ubuntu-jammy"
 #   snapshot_required = true
@@ -23,7 +23,7 @@
 # }
 #
 # module "mirror-b" {
-#   source            = "../../modules/aws/base-vm"
+#   source            = "../modules/aws/base-vm"
 #   description       = "[Scenario B] Traffic Mirror Server"
 #   platform          = "ubuntu-jammy"
 #   snapshot_required = true
@@ -45,7 +45,7 @@
 # }
 #
 # module "mirror-p" {
-#   source            = "../../modules/aws/base-vm"
+#   source            = "../modules/aws/base-vm"
 #   description       = "[Protections] Traffic Mirror Server"
 #   platform          = "ubuntu-jammy"
 #   snapshot_required = true
@@ -67,7 +67,7 @@
 # }
 
 module "traffic-mirror-a" {
-  source        = "../../modules/aws/traffic-mirror"
+  source        = "../modules/aws/traffic-mirror"
   description   = "Traffic Mirror - Scenario A"
   target_nic_id = ""
   name          = "${local.victim-a-vms.tmt-srv1.vm-name}-a"
@@ -84,7 +84,7 @@ module "traffic-mirror-a" {
 }
 
 module "traffic-mirror-b" {
-  source        = "../../modules/aws/traffic-mirror"
+  source        = "../modules/aws/traffic-mirror"
   description   = "Traffic Mirror - Scenario B"
   target_nic_id = ""
   name          = "${local.victim-b-vms.tmt-srv1.vm-name}-b"
@@ -101,7 +101,7 @@ module "traffic-mirror-b" {
 }
 
 module "traffic-mirror-p" {
-  source        = "../../modules/aws/traffic-mirror"
+  source        = "../modules/aws/traffic-mirror"
   description   = "Traffic Mirror - Protections"
   target_nic_id = ""
   name          = "${local.victim-protections-vms.tmt-srv1.vm-name}-protections"

--- a/Enterprise/cl0p/Resources/setup/terraform/range/vendor-requested.tf
+++ b/Enterprise/cl0p/Resources/setup/terraform/range/vendor-requested.tf
@@ -4,7 +4,7 @@
 
 #module "baget-srv1" {
 #  scope             = "dev"
-#  source            = "../../modules/aws/base-vm"
+#  source            = "../modules/aws/base-vm"
 #  description       = "[VICTIM] Mirror server"
 #  platform          = "ubuntu"
 #  snapshot_required = true


### PR DESCRIPTION
fixes #19

## Summary 

1. Fixed source directory module, updates to:
- traffic-mirroring.vendor-request
- _victim-network.tf
- vendor-requested.tf

`terraform init` fails due to `../../modules/aws/<Resource>` should have been `../modules/aws/<Resource>`

2. Fixed Local AMIs to use AWS Defaults, updates to:
- _a-victim-vms.tf
- _b-victim-vms.tf
- external-benevolent-vms.tf