### PR TITLE
Fix xfreerdp syntax change in T1021.001

### DIFF
--- a/ManagedServices/oilrig/Emulation_Plan/yaml/oilrig.yaml
+++ b/ManagedServices/oilrig/Emulation_Plan/yaml/oilrig.yaml
@@ -593,7 +593,7 @@
     linux:
       proc:
         command: |
-          exec-background xfreerdp /u:'#{network.domain.name}\#{initial.target.user}' /p:'#{initial.target.password}' /v:localhost:13389 /cert-ignore
+          exec-background xfreerdp /u:'#{network.domain.name}\#{initial.target.user}' /p:'#{initial.target.password}' /v:localhost:13389 /cert:ignore
 
 
 # Step 8


### PR DESCRIPTION
After kali 2025.3 was updated to xfreerdp3, the syntax change to /cert:ignore