### PR TITLE
Fix killing sshd session in T1070.004 in oilrig.yaml

### DIFF
--- a/ManagedServices/oilrig/Emulation_Plan/yaml/oilrig.yaml
+++ b/ManagedServices/oilrig/Emulation_Plan/yaml/oilrig.yaml
@@ -818,7 +818,7 @@
           xdotool key --window "$rdp_window" Return;
           sleep 2;
           
-          kill $(ps aux | grep "sshd: #{caldera.user.name}" | grep -v priv | grep -v grep | awk '{print $2}')
+          kill $(ps aux | grep "sshd-session: #{caldera.user.name}" | grep -v priv | grep -v grep | awk '{print $2}')
 
 - id: d9c9a941-c0e8-4eed-8cc3-6511ad5b9e15
   name: OilRig Cleanup on Gosta


### PR DESCRIPTION
To kill the sshd tunnel, you need to grep sshd-session